### PR TITLE
Update repo URL after ownership change

### DIFF
--- a/docker/nestrischamps/Dockerfile
+++ b/docker/nestrischamps/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM node:18-alpine
 RUN apk add git
-RUN git clone https://github.com/timotheeg/nestrischamps.git
+RUN git clone https://github.com/nestrischamps/nestrischamps.git
 WORKDIR ./nestrischamps
 COPY *.pem ./
 ARG HTTPS

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -599,7 +599,7 @@
 
 		<p>
 			The list of TODO items is tracked as
-			<a href="https://github.com/timotheeg/nestrischamps/issues"
+			<a href="https://github.com/nestrischamps/nestrischamps/issues"
 				>issues in the github project</a
 			>. Feel free to open feature requests and bug reports there. There's no
 			ETA and guarantee on when anything might get done though, so patience is

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Nestrischamps is a [nodejs](https://nodejs.org/en/) server application and UI. I
 
 #### Clone the project locally from git:
 ```bash
-git clone https://github.com/timotheeg/nestrischamps.git
+git clone https://github.com/nestrischamps/nestrischamps.git
 ```
 
 #### Install nodejs dependencies
@@ -213,7 +213,7 @@ Note that you can specify which language you want the voices to be in by adding 
 
 To contribute, make sure you first set project to run locally (see previous sections), such you can test your code before opening up PRs.
 
-Many issues and ideas for improvements are listed in the [github issues](https://github.com/timotheeg/nestrischamps/issues).
+Many issues and ideas for improvements are listed in the [github issues](https://github.com/nestrischamps/nestrischamps/issues).
 
 The code is sort of messy, and yet, I have some standards hidden in this mess. Until I document them, please ask on [the discord server](https://discord.gg/Wzr4YdQWa4) before submitting PRs.
 

--- a/setup/ec2_ubuntu/setup.sh
+++ b/setup/ec2_ubuntu/setup.sh
@@ -18,12 +18,12 @@ echo "CREATE USER nestrischamps with encrypted password 'nestrischamps'; CREATE 
 
 DB_URL="postgres://nestrischamps:nestrischamps@localhost:5432/nestrischamps?sslmode=disable"
 
-curl -q "https://raw.githubusercontent.com/timotheeg/nestrischamps/main/setup/db.sql" | psql "${DB_URL}"
+curl -q "https://raw.githubusercontent.com/nestrischamps/nestrischamps/main/setup/db.sql" | psql "${DB_URL}"
 
 su - ubuntu
 mkdir -p /home/ubuntu/src
 cd /home/ubuntu/src
-git clone https://github.com/timotheeg/nestrischamps.git
+git clone https://github.com/nestrischamps/nestrischamps.git
 cd nestrischamps
 mkdir -p logs
 git checkout main

--- a/setup/local_rpi/setup.sh
+++ b/setup/local_rpi/setup.sh
@@ -10,7 +10,7 @@ DB_URL="postgres://nestrischamps:nestrischamps@localhost:5432/nestrischamps?sslm
 
 mkdir -p src
 cd src
-git clone https://github.com/timotheeg/nestrischamps.git
+git clone https://github.com/nestrischamps/nestrischamps.git
 cd nestrischamps
 mkdir -p logs
 git checkout main

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -59,7 +59,7 @@
 
 					<hr class="navbar-divider">
 
-					<a class="navbar-item" href="https://github.com/timotheeg/nestrischamps/issues/new">
+					<a class="navbar-item" href="https://github.com/nestrischamps/nestrischamps/issues/new">
 						Report an issue
 					</a>
 				</div>

--- a/views/intro.ejs
+++ b/views/intro.ejs
@@ -314,7 +314,7 @@ VNTPYN</pre>
 						<dd>where H is the <a href="https://en.wikipedia.org/wiki/Web_colors#Hex_triplet">hex representation of a color</a> for the background (defaults to white)</dd>
 					</dl>
 					<pre>?minutes=60&type=down&text_color=ffffff&bg_color=000000</pre>
-					<p>Source code and documentation for the timer is available <a href="https://github.com/timotheeg/nestrischamps/tree/main/public/tools/timer">here</a></p>
+					<p>Source code and documentation for the timer is available <a href="https://github.com/nestrischamps/nestrischamps/tree/main/public/tools/timer">here</a></p>
 				</div>
 			</div>
 			<div class="column is-half">
@@ -333,7 +333,7 @@ VNTPYN</pre>
 						<dd>Indicates whether this is a PAL or NTSC event (defaults to NTSC)</dd>
 					</dl>
 					<pre>?cycle_seconds=15&event=Marq's%20garage%20party</pre>
-					<p>Source code and documentation for the footer is available <a href="https://github.com/timotheeg/nestrischamps/tree/main/public/tools/footer">here</a></p>
+					<p>Source code and documentation for the footer is available <a href="https://github.com/nestrischamps/nestrischamps/tree/main/public/tools/footer">here</a></p>
 				</div>
 			</div>
 		</div>
@@ -351,7 +351,7 @@ VNTPYN</pre>
 				<h2 class="title is-2" id="free_and_open_source">
 					Free and Open Source!
 				</h2>
-				<p>NestrisChamps is Open Source Software, licenced under the MIT licence and <a href="https://github.com/timotheeg/nestrischamps">available on github</a>.</p>
+				<p>NestrisChamps is Open Source Software, licenced under the MIT licence and <a href="https://github.com/nestrischamps/nestrischamps">available on github</a>.</p>
 				<p>That means you can run your own version of NestrisChamps locally if you wish, and have your own database.</p>
 				<p>The online version of NestrisChamps is owned and operated by yobi9 (Find him on <a href="https://discord.gg/Wzr4YdQWa4">discord</a>, <a href="https://www.twitch.tv/yobi9">twitch</a>, <a href="https://github.com/timotheeg">github</a>).</p>
 			</div>

--- a/views/terms.ejs
+++ b/views/terms.ejs
@@ -20,7 +20,7 @@
 		<h1 class="title is-1">
 			NesTrisChamps: Terms of Service
 		</h1>
-		<p class="block">NesTrisChamps is Open Source, hosted on github <a href="https://github.com/timotheeg/nestrischamps">here</a>.</p>
+		<p class="block">NesTrisChamps is Open Source, hosted on github <a href="https://github.com/nestrischamps/nestrischamps">here</a>.</p>
         <p class="block">nestrischamps.io is an online, freely available version of NesTrisChamps.</p>
         <p class="block">It runs on a single server. So, please be nice and do not abuse the service.</p>
 		<p class="block">All game data is freely available to all.</p>


### PR DESCRIPTION
## Context

The NestrisChamps repo has been moved to the nestrischamps org. All urls pointing to Yobi's github user should be updated accordingly.