### PR TITLE
Support Remote Calibration

### DIFF
--- a/domains/MatchRoom.js
+++ b/domains/MatchRoom.js
@@ -452,6 +452,8 @@ class MatchRoom extends Room {
 	}
 
 	async handleAdminMessage(message) {
+		console.log(message);
+
 		const [command, ...args] = message;
 		let forward_to_views = true;
 		let update_admin = true;
@@ -494,6 +496,22 @@ class MatchRoom extends Room {
 						producer.send(['setViewPeerId', this.last_view.id]);
 						producer.send(['makePlayer', p_num, this.getViewMeta()]); // should reset camera!
 					}
+
+					break;
+				}
+
+				case 'requestRemoteCalibration': {
+					update_admin = false;
+					forward_to_views = false;
+
+					const [p_num, admin_peer_id] = args;
+
+					this.assertValidPlayer(p_num);
+
+					const player_id = this.state.players[p_num].id;
+					const user = this.getProducer(player_id);
+
+					user.getProducer()?.send(['requestRemoteCalibration', admin_peer_id]);
 
 					break;
 				}

--- a/public/producer/CaptureDriver.js
+++ b/public/producer/CaptureDriver.js
@@ -46,6 +46,7 @@ export class CaptureDriver extends EventTarget {
 	}
 
 	addPlayer(player) {
+		player._driver = this; // use a method?
 		this.players.push(player);
 	}
 

--- a/public/producer/CaptureDriver.js
+++ b/public/producer/CaptureDriver.js
@@ -138,9 +138,9 @@ export class CaptureDriver extends EventTarget {
 		const now = Date.now();
 
 		if (this.#working) {
-			console.warn(
-				`skip frame. Elapsed: ${now - (this.#then || 0)}. Current player work: ${this.#curPlayerNum}`
-			);
+			// console.warn(
+			// 	`skip frame. Elapsed: ${now - (this.#then || 0)}. Current player work: ${this.#curPlayerNum}`
+			// );
 			return;
 		}
 

--- a/public/producer/CaptureDriver.js
+++ b/public/producer/CaptureDriver.js
@@ -138,9 +138,9 @@ export class CaptureDriver extends EventTarget {
 		const now = Date.now();
 
 		if (this.#working) {
-			// console.warn(
-			// 	`skip frame. Elapsed: ${now - (this.#then || 0)}. Current player work: ${this.#curPlayerNum}`
-			// );
+			console.warn(
+				`skip frame. Elapsed: ${now - (this.#then || 0)}. Current player work: ${this.#curPlayerNum}`
+			);
 			return;
 		}
 

--- a/public/producer/ConfigUtils.js
+++ b/public/producer/ConfigUtils.js
@@ -89,7 +89,7 @@ export async function loadConfig() {
 	}
 }
 
-function getSerializableConfigCopy(config) {
+export function getSerializableConfigCopy(config) {
 	const {
 		device_id,
 		game_type,

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -62,10 +62,17 @@ export class Player extends EventTarget {
 				// stopSharingVideoFeed();
 			},
 
-			requestRemoteCalibration: admin_peer_id => {
+			requestRemoteCalibration: async admin_peer_id => {
 				console.log('requestRemoteCalibration', admin_peer_id);
+
+				if (this.conn) {
+					clearInterval(this.conn.sendJpegIntervalId);
+					this.conn.close();
+				}
+
 				const video = this._driver.getVideo();
-				this.#peer.call(admin_peer_id, video.srcObject, {
+
+				this.conn = this.#peer.connect(admin_peer_id, {
 					metadata: {
 						video: {
 							width: video.videoWidth,
@@ -74,14 +81,59 @@ export class Player extends EventTarget {
 						config: getSerializableConfigCopy(this.config),
 					},
 				});
-				// makes a call to admin caller and pass config
-				// need access to driver
+
+				const sendJpeg = async () => {
+					const jpeg = await this.#getVideoFrameAsJpegBlob();
+					this.conn.send({ jpeg });
+				};
+
+				this.conn.on('open', () => {
+					clearInterval(this.conn.sendJpegIntervalId);
+					this.conn.sendJpegIntervalId = setInterval(sendJpeg, 10000);
+					sendJpeg();
+				});
+
+				this.conn.on('data', ({ config }) => {
+					for (const [name, task] of Object.entries(config.tasks)) {
+						Object.assign(this.config.tasks[name].crop, task.crop);
+					}
+
+					// TODO: carry score7 and reset entire config
+
+					this.config.save();
+				});
+
+				this.conn.on('close', () => {
+					clearInterval(this.conn.sendJpegIntervalId);
+				});
 			},
 
 			setVdoNinjaURL: () => {},
 		};
 
 		this.connect();
+	}
+
+	// manua async
+	#getVideoFrameAsJpegBlob() {
+		const video = this._driver.getVideo();
+
+		const canvas = document.createElement('canvas');
+		canvas.width = video.videoWidth;
+		canvas.height = video.videoHeight;
+		const ctx = canvas.getContext('2d');
+
+		// Draw the current video frame into the canvas
+		ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+		// Convert to JPEG Blob at 85% quality
+		return new Promise(resolve => {
+			canvas.toBlob(
+				blob => resolve(blob),
+				'image/jpeg',
+				0.75 // quality 0..1
+			);
+		});
 	}
 
 	processVideoFrame(frame) {

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -123,17 +123,28 @@ export class Player extends EventTarget {
 	#getVideoFrameAsWebpBlob() {
 		const video = this._driver.getVideo();
 
-		const canvas = document.createElement('canvas');
-		canvas.width = video.videoWidth;
-		canvas.height = video.videoHeight;
-		const ctx = canvas.getContext('2d');
+		if (!this.remote_calibration_canvas) {
+			// lazy initialization of the remote calibration canvas
+			this.remote_calibration_canvas = document.createElement('canvas');
+			this.remote_calibration_canvas.width = video.videoWidth;
+			this.remote_calibration_canvas.height = video.videoHeight;
+			this.remote_calibration_canvas_ctx =
+				this.remote_calibration_canvas.getContext('2d', { alpha: false });
+			this.remote_calibration_canvas_ctx.imageSmoothingEnabled = false;
+		}
 
 		// Draw the current video frame into the canvas
-		ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+		this.remote_calibration_canvas_ctx.drawImage(
+			video,
+			0,
+			0,
+			this.remote_calibration_canvas.width,
+			this.remote_calibration_canvas.height
+		);
 
 		// Convert to JPEG Blob at 85% quality
 		return new Promise(resolve => {
-			canvas.toBlob(
+			this.remote_calibration_canvas.toBlob(
 				blob => resolve(blob),
 				'image/webp',
 				0.5 // quality 0..1

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -98,6 +98,11 @@ export class Player extends EventTarget {
 						Object.assign(this.config.tasks[name].crop, task.crop);
 					}
 
+					// TODO: how to update the controls?
+					['brightness', 'contrast'].forEach(prop => {
+						if (prop in config) this.config[prop] = config[prop];
+					});
+
 					// TODO: carry score7 and reset entire config
 
 					this.config.save();

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -2,6 +2,8 @@ import QueryString from '/js/QueryString.js';
 import BinaryFrame from '/js/BinaryFrame.js';
 import Connection from '/js/connection.js';
 
+import { peerServerOptions } from '/views/constants.js';
+
 import GameTracker from './GameTracker.js';
 import { CpuTetrisOCR } from './cpuTetrisOCR.js';
 import { WGpuTetrisOCR } from './wgpuTetrisOCR.js';
@@ -15,6 +17,7 @@ export class Player extends EventTarget {
 	#startTime;
 	#lastFrame;
 	#connection = null;
+	#peer;
 
 	constructor(config, num = null) {
 		super();
@@ -48,12 +51,25 @@ export class Player extends EventTarget {
 			makePlayer: (player_index, _view_meta) => {
 				this.is_player = true;
 				this.view_meta = _view_meta;
+				// startSharingVideoFeed();
 			},
 
 			dropPlayer() {
 				this.is_player = false;
 				this.view_meta = null;
+				// stopSharingVideoFeed();
 			},
+
+			requestRemoteCalibration: admin_peer_id => {
+				console.log('requestRemoteCalibration', admin_peer_id);
+				this.#peer.call(admin_peer_id, this._driver.getVideo().srcObject, {
+					config: { foo: [1, 5, 8] },
+				});
+				// makes a call to admin caller and pass config
+				// need access to driver
+			},
+
+			setVdoNinjaURL: () => {},
 		};
 
 		this.connect();
@@ -162,21 +178,21 @@ export class Player extends EventTarget {
 		this.#connection.onResume = this.resetNotice;
 
 		this.#connection.onInit = () => {
-			// if (peer) {
-			// 	peer.removeAllListeners();
-			// 	peer.destroy();
-			// 	peer = null;
-			// }
-			// peer = new Peer(this.#connection.id, peerServerOptions);
-			// peer.on('open', err => {
-			// 	console.log(Date.now(), 'peer opened', peer.id);
-			// 	//startSharingVideoFeed();
-			// });
-			// peer.on('error', err => {
-			// 	console.log(`Peer error: ${err.message}`);
-			// 	peer.retryTO = clearTimeout(peer.retryTO); // there should only be one retry scheduled
-			// 	// peer.retryTO = setTimeout(startSharingVideoFeed, 1500); // we assume this will succeed at some point?? 😰😅
-			// });
+			if (this.#peer) {
+				this.#peer.removeAllListeners();
+				this.#peer.destroy();
+				this.#peer = null;
+			}
+			this.#peer = new Peer(this.#connection.id, peerServerOptions);
+			this.#peer.on('open', err => {
+				console.log(Date.now(), 'peer opened', this.#peer.id);
+				//startSharingVideoFeed();
+			});
+			this.#peer.on('error', err => {
+				console.log(`Peer error: ${err.message}`);
+				this.#peer.retryTO = clearTimeout(this.#peer.retryTO); // there should only be one retry scheduled
+				// this.#peer.retryTO = setTimeout(startSharingVideoFeed, 1500); // we assume this will succeed at some point?? 😰😅
+			});
 		};
 
 		return this.#connection;

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -4,6 +4,8 @@ import Connection from '/js/connection.js';
 
 import { peerServerOptions } from '/views/constants.js';
 
+import { getSerializableConfigCopy } from './ConfigUtils.js';
+
 import GameTracker from './GameTracker.js';
 import { CpuTetrisOCR } from './cpuTetrisOCR.js';
 import { WGpuTetrisOCR } from './wgpuTetrisOCR.js';
@@ -62,8 +64,15 @@ export class Player extends EventTarget {
 
 			requestRemoteCalibration: admin_peer_id => {
 				console.log('requestRemoteCalibration', admin_peer_id);
-				this.#peer.call(admin_peer_id, this._driver.getVideo().srcObject, {
-					config: { foo: [1, 5, 8] },
+				const video = this._driver.getVideo();
+				this.#peer.call(admin_peer_id, video.srcObject, {
+					metadata: {
+						video: {
+							width: video.videoWidth,
+							height: video.videoHeight,
+						},
+						config: getSerializableConfigCopy(this.config),
+					},
 				});
 				// makes a call to admin caller and pass config
 				// need access to driver

--- a/public/producer/Player.js
+++ b/public/producer/Player.js
@@ -66,7 +66,7 @@ export class Player extends EventTarget {
 				console.log('requestRemoteCalibration', admin_peer_id);
 
 				if (this.conn) {
-					clearInterval(this.conn.sendJpegIntervalId);
+					clearInterval(this.conn.sendWebpIntervalId);
 					this.conn.close();
 				}
 
@@ -82,15 +82,15 @@ export class Player extends EventTarget {
 					},
 				});
 
-				const sendJpeg = async () => {
-					const jpeg = await this.#getVideoFrameAsJpegBlob();
-					this.conn.send({ jpeg });
+				const sendWebp = async () => {
+					const webp = await this.#getVideoFrameAsWebpBlob();
+					this.conn.send({ webp });
 				};
 
 				this.conn.on('open', () => {
-					clearInterval(this.conn.sendJpegIntervalId);
-					this.conn.sendJpegIntervalId = setInterval(sendJpeg, 10000);
-					sendJpeg();
+					clearInterval(this.conn.sendWebpIntervalId);
+					this.conn.sendWebpIntervalId = setInterval(sendWebp, 10000);
+					sendWebp();
 				});
 
 				this.conn.on('data', ({ config }) => {
@@ -104,7 +104,7 @@ export class Player extends EventTarget {
 				});
 
 				this.conn.on('close', () => {
-					clearInterval(this.conn.sendJpegIntervalId);
+					clearInterval(this.conn.sendWebpIntervalId);
 				});
 			},
 
@@ -115,7 +115,7 @@ export class Player extends EventTarget {
 	}
 
 	// manua async
-	#getVideoFrameAsJpegBlob() {
+	#getVideoFrameAsWebpBlob() {
 		const video = this._driver.getVideo();
 
 		const canvas = document.createElement('canvas');
@@ -130,8 +130,8 @@ export class Player extends EventTarget {
 		return new Promise(resolve => {
 			canvas.toBlob(
 				blob => resolve(blob),
-				'image/jpeg',
-				0.75 // quality 0..1
+				'image/webp',
+				0.5 // quality 0..1
 			);
 		});
 	}

--- a/public/producer/components/NtcComponent.js
+++ b/public/producer/components/NtcComponent.js
@@ -1,4 +1,4 @@
-async function getBulmaSheets() {
+function getBulmaSheets() {
 	return Promise.all(
 		['/vendor/bulma.1.0.4.min.css', '/vendor/bulma.ntc.css'].map(url =>
 			fetch(url)
@@ -14,7 +14,7 @@ async function getBulmaSheets() {
 
 let bulmaSheetsPromise;
 
-function lazyBulmaSheets() {
+export function lazyBulmaSheets() {
 	if (!bulmaSheetsPromise) {
 		bulmaSheetsPromise = getBulmaSheets(); // no await!
 	}
@@ -28,7 +28,7 @@ export class NtcComponent extends HTMLElement {
 
 		this.shadow = this.attachShadow({ mode: 'open' });
 
-		this._bulmaSheets = window.BULMA_STYLESHEETS || lazyBulmaSheets();
+		this._bulmaSheets = lazyBulmaSheets();
 
 		// NTC components will inherit bulma styles
 		this._bulmaSheets.then(sheets => {

--- a/public/producer/components/NtcComponent.js
+++ b/public/producer/components/NtcComponent.js
@@ -1,11 +1,37 @@
+async function getBulmaSheets() {
+	return Promise.all(
+		['/vendor/bulma.1.0.4.min.css', '/vendor/bulma.ntc.css'].map(url =>
+			fetch(url)
+				.then(res => res.text())
+				.then(css => {
+					const sheet = new CSSStyleSheet();
+					sheet.replaceSync(css);
+					return sheet;
+				})
+		)
+	);
+}
+
+let bulmaSheetsPromise;
+
+function lazyBulmaSheets() {
+	if (!bulmaSheetsPromise) {
+		bulmaSheetsPromise = getBulmaSheets(); // no await!
+	}
+
+	return bulmaSheetsPromise;
+}
+
 export class NtcComponent extends HTMLElement {
 	constructor() {
 		super();
 
 		this.shadow = this.attachShadow({ mode: 'open' });
 
+		this._bulmaSheets = window.BULMA_STYLESHEETS || lazyBulmaSheets();
+
 		// NTC components will inherit bulma styles
-		window.BULMA_STYLESHEETS.then(sheets => {
+		this._bulmaSheets.then(sheets => {
 			this.shadow.adoptedStyleSheets = [...sheets];
 		});
 	}

--- a/public/producer/components/PerfResults.js
+++ b/public/producer/components/PerfResults.js
@@ -32,7 +32,7 @@ export class NTC_PerfResults extends NtcComponent {
 
 		this.shadow.innerHTML = MARKUP;
 
-		window.BULMA_STYLESHEETS.then(() => {
+		this._bulmaSheets.then(() => {
 			this.shadow.adoptedStyleSheets.push(cssOverride);
 		});
 

--- a/public/producer/components/calibration.js
+++ b/public/producer/components/calibration.js
@@ -500,22 +500,28 @@ export class NTC_Producer_Calibration extends NtcComponent {
 		capture.replaceChildren(ocr.capture_canvas, ocr.output_canvas);
 
 		adjustments.replaceChildren(
-			...Object.entries(ocr.config.tasks).map(([name, task]) => {
-				const control = document.createElement('ntc-cropcontrol');
+			...Object.keys(TASK_RESIZE) // ensures consistent order
+				.map(name => {
+					const task = ocr.config.tasks[name];
 
-				control.id = name;
+					if (!task) return null;
 
-				if (/^color/.test(name)) {
-					control.setAttribute('bind', 'colors-xw');
-				} else if (name.length === 1) {
-					control.setAttribute('bind', 'stats-xw');
-				}
+					const control = document.createElement('ntc-cropcontrol');
 
-				control.setCoordinates(task.crop);
-				control.setCaptureCanvas(task.canvas);
+					control.id = name;
 
-				return control;
-			})
+					if (/^color/.test(name)) {
+						control.setAttribute('bind', 'colors-xw');
+					} else if (name.length === 1) {
+						control.setAttribute('bind', 'stats-xw');
+					}
+
+					control.setCoordinates(task.crop);
+					control.setCaptureCanvas(task.canvas);
+
+					return control;
+				})
+				.filter(v => v)
 		);
 
 		capture_rate.value = this.ocr.config.frame_rate || 60;

--- a/public/producer/components/calibration.js
+++ b/public/producer/components/calibration.js
@@ -155,7 +155,7 @@ export class NTC_Producer_Calibration extends NtcComponent {
 	constructor() {
 		super();
 
-		window.BULMA_STYLESHEETS.then(() => {
+		this._bulmaSheets.then(() => {
 			this.shadow.adoptedStyleSheets.push(cssOverride);
 		});
 

--- a/public/producer/components/calibration.js
+++ b/public/producer/components/calibration.js
@@ -234,7 +234,7 @@ export class NTC_Producer_Calibration extends NtcComponent {
 		if (!this.ocr?.config?.tasks?.[name]) return;
 
 		this.ocr.config.tasks[name].crop[key] = value;
-		this.ocr.config.save(name);
+		this.ocr.config.save([name]);
 
 		this.#restartHidePartsTimeout();
 	};
@@ -246,15 +246,15 @@ export class NTC_Producer_Calibration extends NtcComponent {
 			detail: { group, key, value },
 		} = event;
 
-		[...group]
+		const names = [...group]
 			.map(element => element.id)
-			.forEach(name => {
-				if (!this.ocr?.config?.tasks?.[name]) return;
+			.filter(name => this.ocr?.config?.tasks?.[name]);
 
-				this.ocr.config.tasks[name].crop[key] = value;
-			});
+		names.forEach(name => {
+			this.ocr.config.tasks[name].crop[key] = value;
+		});
 
-		this.ocr.config.save();
+		this.ocr.config.save(names);
 	};
 
 	connectedCallback() {

--- a/public/producer/components/calibration.js
+++ b/public/producer/components/calibration.js
@@ -93,9 +93,7 @@ const MARKUP = html`
 
 		<div id="extraction" class="columns">
 			<div id="capture-container" class="column is-5">
-				<div id="capture">
-					<video id="device_video" playsinline controls="false"></video>
-				</div>
+				<div id="capture"></div>
 			</div>
 			<div id="adjustments" class="column is-7" data-crop-scope></div>
 		</div>
@@ -236,7 +234,7 @@ export class NTC_Producer_Calibration extends NtcComponent {
 		if (!this.ocr?.config?.tasks?.[name]) return;
 
 		this.ocr.config.tasks[name].crop[key] = value;
-		this.ocr.config.save();
+		this.ocr.config.save(name);
 
 		this.#restartHidePartsTimeout();
 	};

--- a/public/producer/components/cropcontrol.js
+++ b/public/producer/components/cropcontrol.js
@@ -70,7 +70,7 @@ export class NTC_Crop_Control extends NtcComponent {
 	constructor() {
 		super();
 
-		window.BULMA_STYLESHEETS.then(() => {
+		this._bulmaSheets.then(() => {
 			this.shadow.adoptedStyleSheets.push(cssOverride);
 		});
 

--- a/public/producer/components/multiview/index.js
+++ b/public/producer/components/multiview/index.js
@@ -78,7 +78,7 @@ export class NTC_MultiView extends NtcComponent {
 	constructor() {
 		super();
 
-		window.BULMA_STYLESHEETS.then(() => {
+		this._bulmaSheets.then(() => {
 			this.shadow.adoptedStyleSheets.push(cssOverride);
 		});
 

--- a/public/producer/components/roomview.js
+++ b/public/producer/components/roomview.js
@@ -28,7 +28,7 @@ export class NTC_Producer_RoomView extends NtcComponent {
 	constructor() {
 		super();
 
-		window.BULMA_STYLESHEETS.then(() => {
+		this._bulmaSheets.then(() => {
 			this.shadow.adoptedStyleSheets.push(cssOverride);
 		});
 

--- a/public/producer/components/settings.js
+++ b/public/producer/components/settings.js
@@ -89,7 +89,7 @@ export class NTC_Producer_Settings extends NtcComponent {
 	constructor() {
 		super();
 
-		window.BULMA_STYLESHEETS.then(() => {
+		this._bulmaSheets.then(() => {
 			this.shadow.adoptedStyleSheets.push(cssOverride);
 		});
 

--- a/public/producer/components/wizard.js
+++ b/public/producer/components/wizard.js
@@ -194,7 +194,7 @@ export class NTC_Producer_Wizard extends NtcComponent {
 	constructor() {
 		super();
 
-		window.BULMA_STYLESHEETS.then(() => {
+		this._bulmaSheets.then(() => {
 			this.shadow.adoptedStyleSheets.push(cssOverride);
 		});
 

--- a/public/producer/index.html
+++ b/public/producer/index.html
@@ -3,18 +3,8 @@
 	<head>
 		<title>NestrisChamps Producer</title>
 		<script type="module">
-			window.BULMA_STYLESHEETS = Promise.all(
-				['/vendor/bulma.1.0.4.min.css', '/vendor/bulma.ntc.css'].map(url =>
-					fetch(url)
-						.then(res => res.text())
-						.then(css => {
-							const sheet = new CSSStyleSheet();
-							sheet.replaceSync(css);
-							return sheet;
-						})
-				)
-			);
-			window.BULMA_STYLESHEETS.then(sheets => {
+			import { lazyBulmaSheets } from '/producer/components/NtcComponent.js';
+			lazyBulmaSheets().then(sheets => {
 				document.adoptedStyleSheets = sheets;
 				document.querySelector('body').classList.remove('loading');
 			});

--- a/public/producer/remote_calibration.html
+++ b/public/producer/remote_calibration.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>NestrisChamps Producer</title>
+		<script type="module">
+			import '/producer/components/calibration.js';
+
+			import { lazyBulmaSheets } from '/producer/components/NtcComponent.js';
+			lazyBulmaSheets().then(sheets => {
+				document.adoptedStyleSheets = sheets;
+				document.querySelector('body').classList.remove('loading');
+			});
+		</script>
+		<style type="text/css">
+			html,
+			body {
+				height: 100%;
+				margin: 0;
+				padding: 0;
+				overflow: hidden;
+			}
+			body.loading {
+				background: black; /* black FOUC better than white */
+			}
+			.full-viewport {
+				height: 100vh;
+				overflow: hidden;
+			}
+			.scroll-area {
+				overflow-x: hidden;
+				overflow-y: auto;
+				flex: 1 1 auto;
+			}
+		</style>
+	</head>
+	<body class="loading">
+		<div class="full-viewport is-flex is-flex-direction-column">
+			<div class="p-5 is-size-5 is-flex is-justify-content-space-between">
+				<div class="left">
+					Remote calibration for user: <strong id="name"></strong>
+				</div>
+				<div class="right">
+					<button id="close_only" class="button is-warning">
+						Close WITHOUT Saving
+					</button>
+					<button id="save_and_close" class="button is-success">
+						Apply and Close
+					</button>
+				</div>
+			</div>
+			<ntc-calibration
+				class="scroll-area"
+				id="calibration"
+				enable-show-parts="false"
+				enable-use-half-height="false"
+				enable-capture-rate="false"
+			></ntc-calibration>
+		</div>
+	</body>
+</html>

--- a/public/producer/remote_calibration.html
+++ b/public/producer/remote_calibration.html
@@ -40,7 +40,7 @@
 					Remote calibration for user: <strong id="name"></strong>
 				</div>
 				<div class="right">
-					<button id="close_only" class="button is-warning">
+					<button id="close_only" class="button is-warning is-hidden">
 						Close WITHOUT Saving
 					</button>
 					<button id="save_and_close" class="button is-success">

--- a/public/producer/timer.js
+++ b/public/producer/timer.js
@@ -22,11 +22,17 @@ export const timer = {
 	callbacks: {},
 	worker: null,
 	setInterval: function (callback, ms) {
+		if (!this.worker) {
+			return setInterval(callback, ms);
+		}
 		this.callbacks[++this.callid] = callback;
 		this.worker.postMessage(['setInterval', ms, this.callid]);
 		return this.callid;
 	},
 	clearInterval: function (id) {
+		if (!this.worker) {
+			return clearInterval(id);
+		}
 		delete this.callbacks[id];
 		this.worker.postMessage(['clearInterval', id]);
 	},

--- a/public/producer/wgpuTetrisOCR.js
+++ b/public/producer/wgpuTetrisOCR.js
@@ -14,7 +14,9 @@ async function loadShaderSource(url) {
 }
 
 async function getGPU() {
-	const adapter = await navigator.gpu.requestAdapter();
+	const adapter = await navigator.gpu.requestAdapter({
+		powerPreference: 'high-performance',
+	});
 	const device = await adapter.requestDevice();
 	const canvasFormat = navigator.gpu.getPreferredCanvasFormat();
 

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -1,11 +1,10 @@
 import Connection from '/js/connection.js';
 import { peerServerOptions } from '/views/constants.js';
 
-import '/producer/components/calibration.js';
-
+import { getSerializableConfigCopy } from '/producer/ConfigUtils.js';
+import { sleep } from '/producer/timer.js';
 import { CaptureDriver } from '/producer/CaptureDriver.js';
 import { CpuTetrisOCR } from '/producer/cpuTetrisOCR.js';
-import { WGpuTetrisOCR } from '/producer/wgpuTetrisOCR.js';
 
 const dom = {
 	roomid: document.querySelector('#roomid'),
@@ -185,12 +184,8 @@ class Player {
 			remoteAPI.focusPlayer(this.idx);
 		};
 
-		this.dom.remote_calibration_btn.onclick = () => {
-			// doing things like a pig for now...
-			const peerid = `${connection.id}-${this.idx}`;
-			const peer = (this.peer = new Peer(peerid, peerServerOptions));
-
-			const overlay = document.createElement('ntc-calibration');
+		this.dom.remote_calibration_btn.onclick = async () => {
+			let overlay = document.createElement('iframe');
 
 			// Style it to cover 100% of the viewport
 			Object.assign(overlay.style, {
@@ -199,45 +194,129 @@ class Player {
 				left: '0',
 				width: '100vw',
 				height: '100vh',
-				backgroundColor: 'rgba(0, 0, 0, 0.5)', // example semi-transparent background
+				backgroundColor: 'rgba(0, 0, 0, 0.8)', // example semi-transparent background
 				zIndex: '9999', // make sure it's on top
 				overflowY: 'auto', // adds scroll only when needed
 				overflowX: 'hidden', // optional: prevent horizontal scroll
+				margin: 0,
+				padding: 0,
+				border: 0,
 			});
 
+			overlay.src = '/remote_calibration';
 			document.body.appendChild(overlay);
 
-			let driver;
-			let ocr;
+			overlay.addEventListener('load', () => {
+				const clearPeer = () => {
+					if (!this.peer) return;
+					// this.peer.removeAllListeners();
+					this.peer.destroy();
+					this.peer = null;
+				};
 
-			peer.on('call', call => {
-				console.log(call.metadata);
+				const clearAll = () => {
+					// TODO destroy processingpipeline (driver + ocr + calibration_ui)
+					// overlay.removeAllListeners();
+					// closeOnly.removeAllListeners();
+					// saveAndClose.removeAllListeners();
+					overlay.remove();
+					overlay = null;
+					this.dataConnection = null;
+					if (driver) driver.destroy();
+					clearPeer();
+				};
 
-				// TODO: verify it's a known peer?
-				call.on('stream', remoteStream => {
-					const config = call.metadata.config;
-					config.save = function () {};
+				const doc = overlay.contentDocument || overlay.contentWindow.document;
+				const closeOnly = doc.getElementById('close_only');
+				const saveAndClose = doc.getElementById('save_and_close');
 
-					ocr = navigator.gpu?.requestAdapter
-						? new WGpuTetrisOCR(config)
-						: new CpuTetrisOCR(config);
+				// set up ui
+				doc.getElementById('name').innerText = this.dom.name.value;
 
-					overlay.setOCR(ocr);
+				const saveConfig = name => {
+					let config = getSerializableConfigCopy(
+						this.dataConnection.metadata.config
+					);
 
-					driver = new CaptureDriver(config, remoteStream);
+					// cleanup to send the absolute minimum
+					for (const [name, task] of Object.entries(config.tasks)) {
+						config.tasks[name] = { crop: task.crop };
+					}
+
+					if (name) {
+						// only send the config being changed
+						config = {
+							tasks: {
+								[name]: {
+									crop: config.tasks[name].crop,
+								},
+							},
+						};
+					}
+
+					this.dataConnection.send({ config });
+				};
+
+				closeOnly.addEventListener('click', clearAll);
+				saveAndClose.addEventListener('click', async () => {
+					saveConfig();
+					clearAll();
+				});
+
+				const calibration = doc.getElementById('calibration');
+
+				if (this.peer) {
+					clearPeer();
+				}
+
+				const peerid = `${connection.id}-${this.idx}`;
+				const peer = (this.peer = new Peer(peerid, peerServerOptions));
+
+				let driver;
+				let ocr;
+				let srcCanvas;
+				let srcCtx;
+
+				peer.on('connection', async dataConnection => {
+					this.dataConnection = dataConnection;
+
+					const { config, video } = dataConnection.metadata;
+					config.save = function (name) {
+						saveConfig(name);
+					};
+
+					ocr = new CpuTetrisOCR(config);
+
+					calibration.setOCR(ocr);
+
+					srcCanvas = document.createElement('canvas');
+					srcCanvas.width = video.width;
+					srcCanvas.height = video.height;
+
+					srcCtx = srcCanvas.getContext('2d');
+
+					// receive new frames (VERY low frame rate)
+					dataConnection.on('data', async data => {
+						if (!data.jpeg) return;
+
+						const blob = new Blob([data.jpeg], { type: 'image/jpeg' });
+						const bitmap = await createImageBitmap(blob);
+						srcCtx.drawImage(bitmap, 0, 0);
+					});
+
+					const stream = srcCanvas.captureStream(10);
+
+					driver = new CaptureDriver(config, stream);
 					driver.addPlayer({
 						processVideoFrame(frame) {
 							ocr.processVideoFrame(frame);
 						},
 					});
 				});
-				call.answer();
-				// call.send(); No send on mediaConnections
-			});
 
-			peer.on('open', id => {
-				console.log({ peerid, id });
-				remoteAPI.requestRemoteCalibration(this.idx, peerid);
+				peer.on('open', id => {
+					remoteAPI.requestRemoteCalibration(this.idx, peerid);
+				});
 			});
 		};
 	}

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -1,6 +1,12 @@
 import Connection from '/js/connection.js';
 import { peerServerOptions } from '/views/constants.js';
 
+import '/producer/components/calibration.js';
+
+import { CaptureDriver } from '/producer/CaptureDriver.js';
+import { CpuTetrisOCR } from '/producer/cpuTetrisOCR.js';
+import { WGpuTetrisOCR } from '/producer/wgpuTetrisOCR.js';
+
 const dom = {
 	roomid: document.querySelector('#roomid'),
 	producer_count: document.querySelector('#producer_count'),
@@ -184,7 +190,7 @@ class Player {
 			const peerid = `${connection.id}-${this.idx}`;
 			const peer = (this.peer = new Peer(peerid, peerServerOptions));
 
-			const overlay = document.createElement('div');
+			const overlay = document.createElement('ntc-calibration');
 
 			// Style it to cover 100% of the viewport
 			Object.assign(overlay.style, {
@@ -195,22 +201,38 @@ class Player {
 				height: '100vh',
 				backgroundColor: 'rgba(0, 0, 0, 0.5)', // example semi-transparent background
 				zIndex: '9999', // make sure it's on top
+				overflowY: 'auto', // adds scroll only when needed
+				overflowX: 'hidden', // optional: prevent horizontal scroll
 			});
 
 			document.body.appendChild(overlay);
 
-			const video = document.createElement('video');
-			video.autoplay = true;
-			overlay.appendChild(video);
+			let driver;
+			let ocr;
 
 			peer.on('call', call => {
 				console.log(call.metadata);
 
 				// TODO: verify it's a known peer?
 				call.on('stream', remoteStream => {
-					video.srcObject = remoteStream;
+					const config = call.metadata.config;
+					config.save = function () {};
+
+					ocr = navigator.gpu?.requestAdapter
+						? new WGpuTetrisOCR(config)
+						: new CpuTetrisOCR(config);
+
+					overlay.setOCR(ocr);
+
+					driver = new CaptureDriver(config, remoteStream);
+					driver.addPlayer({
+						processVideoFrame(frame) {
+							ocr.processVideoFrame(frame);
+						},
+					});
 				});
 				call.answer();
+				// call.send(); No send on mediaConnections
 			});
 
 			peer.on('open', id => {

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -238,7 +238,7 @@ class Player {
 				// set up ui
 				doc.getElementById('name').innerText = this.dom.name.value;
 
-				const saveConfig = name => {
+				const saveConfig = names => {
 					let config = getSerializableConfigCopy(
 						this.dataConnection.metadata.config
 					);
@@ -248,14 +248,13 @@ class Player {
 						config.tasks[name] = { crop: task.crop };
 					}
 
-					if (name) {
+					if (names) {
 						// only send the config being changed
 						config = {
-							tasks: {
-								[name]: {
-									crop: config.tasks[name].crop,
-								},
-							},
+							tasks: names.reduce((acc, name) => {
+								acc[name] = { crop: config.tasks[name].crop };
+								return acc;
+							}, {}),
 						};
 					}
 

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -1,4 +1,6 @@
 import Connection from '/js/connection.js';
+import QueryString from '/js/QueryString.js';
+
 import { peerServerOptions } from '/views/constants.js';
 
 import { getSerializableConfigCopy } from '/producer/ConfigUtils.js';
@@ -54,6 +56,9 @@ class Player {
 		this.dom = dom;
 
 		this.setIndex(idx);
+
+		if (QueryString.get('rcal') !== '1')
+			this.dom.remote_calibration_btn.remove();
 
 		this.victories = 0;
 		this.bestof = -1;
@@ -297,9 +302,9 @@ class Player {
 
 					// receive new frames (VERY low frame rate)
 					dataConnection.on('data', async data => {
-						if (!data.jpeg) return;
+						if (!data.webp) return;
 
-						const blob = new Blob([data.jpeg], { type: 'image/jpeg' });
+						const blob = new Blob([data.webp], { type: 'image/webp' });
 						const bitmap = await createImageBitmap(blob);
 						srcCtx.drawImage(bitmap, 0, 0);
 					});

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -1,4 +1,5 @@
 import Connection from '/js/connection.js';
+import { peerServerOptions } from '/views/constants.js';
 
 const dom = {
 	roomid: document.querySelector('#roomid'),
@@ -176,6 +177,46 @@ class Player {
 
 		this.dom.focus_player_btn.onclick = () => {
 			remoteAPI.focusPlayer(this.idx);
+		};
+
+		this.dom.remote_calibration_btn.onclick = () => {
+			// doing things like a pig for now...
+			const peerid = `${connection.id}-${this.idx}`;
+			const peer = (this.peer = new Peer(peerid, peerServerOptions));
+
+			const overlay = document.createElement('div');
+
+			// Style it to cover 100% of the viewport
+			Object.assign(overlay.style, {
+				position: 'fixed',
+				top: '0',
+				left: '0',
+				width: '100vw',
+				height: '100vh',
+				backgroundColor: 'rgba(0, 0, 0, 0.5)', // example semi-transparent background
+				zIndex: '9999', // make sure it's on top
+			});
+
+			document.body.appendChild(overlay);
+
+			const video = document.createElement('video');
+			video.autoplay = true;
+			overlay.appendChild(video);
+
+			peer.on('call', call => {
+				console.log(call.metadata);
+
+				// TODO: verify it's a known peer?
+				call.on('stream', remoteStream => {
+					video.srcObject = remoteStream;
+				});
+				call.answer();
+			});
+
+			peer.on('open', id => {
+				console.log({ peerid, id });
+				remoteAPI.requestRemoteCalibration(this.idx, peerid);
+			});
 		};
 	}
 
@@ -406,6 +447,7 @@ function addPlayer() {
 		camera_restart_btn: player_node.querySelector('.camera_restart'),
 		camera_mirror_btn: player_node.querySelector('.camera_mirror'),
 		focus_player_btn: player_node.querySelector('.focus_player'),
+		remote_calibration_btn: player_node.querySelector('.remote_calibration'),
 		vdo_ninja_url: player_node.querySelector('.vdo_ninja_url'),
 	});
 

--- a/public/views/competition_admin.js
+++ b/public/views/competition_admin.js
@@ -243,7 +243,7 @@ class Player {
 						this.dataConnection.metadata.config
 					);
 
-					// cleanup to send the absolute minimum
+					// cleanup to send just the crop
 					for (const [name, task] of Object.entries(config.tasks)) {
 						config.tasks[name] = { crop: task.crop };
 					}

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -71,6 +71,12 @@ router.get(
 );
 /**/
 
+router.get(/^\/remote_calibration/, (req, res) => {
+	res.sendFile(
+		path.join(path.resolve(), `public/producer/remote_calibration.html`)
+	);
+});
+
 router.get(
 	/^\/room\/(producer2?|emu)/,
 	middlewares.assertSession,

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -315,12 +315,14 @@
 					</p>
 					<p>
 						<button class="focus_player">Focus Player</button>
+						<button class="remote_calibration">Fix Calibration Remotely</button>
 					</p>
 				</div>
 			</div>
 		</template>
 
 		<script src="/vendor/lodash.4.17.21.min.js"></script>
+		<script src="/vendor/peerjs.1.5.4.min.js"></script>
 		<script type="module" src="/views/competition_admin.js"></script>
 	</body>
 </html>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -315,7 +315,7 @@
 					</p>
 					<p>
 						<button class="focus_player">Focus Player</button>
-						<button class="remote_calibration">Fix Calibration Remotely</button>
+						<button class="remote_calibration">Tune Calibration Remotely</button>
 					</p>
 				</div>
 			</div>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -315,7 +315,7 @@
 					</p>
 					<p>
 						<button class="focus_player">Focus Player</button>
-						<button class="remote_calibration">Tune Calibration Remotely</button>
+						<button class="remote_calibration">Remote Calibration</button>
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
## Context
It is difficult to:
1. Ensure players have done a clean calibration
2. Teach players to calibrate properly
3. Have players calibrate well before events

At an event, if a player is not well calibrated, the game host, from the admin page would like to be able to tune the player config remotely.

This PR introduces that remote calibration capability to NTC

## How to use:

1. Load amin page with query string `rcal=1` to activate the button
2. Assign a user to a player
3. Ensure player is using the new `/producer2` page
4. Click button `Remote Calibration`
5. Wait till the peer-to-peer connection is established
6. tune calibration on admin page
7. close remote calibration on admin page

## Known issues / Quirks

* the player controls at producer do not reflect the new values
* switching to score 7 remotely is not implemented
* controls which are group-bound (e.g. colors, piece stats), do not send all their crop updates in real time, use the `Apply and Close` button to update the rest
* No loading indicator
* No error handling if no user is assigned to player

## How it works:

* Send frames at 0.1fps in webp format over peer-to-peer data connection
* Frame are drawn to canvas and a stream is generated from the canvas
* stream is used as input to a capture driver as normal
* The calibration UI is reused as-is

⚠️ Note: this is not using a media peer-to-peer connection!! It sends a `webp` image with a very frame rate of 0.1fps, to ensure the image shows with the right size and pixel accuracy. Media peer-to-peer connection optimize for bandwidth and throughput, and the video stream starts with a lower resolution than at the source, and with very high compression. for a remote calibration, we need to have an image of decent quality from the get go, and a high frame rate is irrelevant.


